### PR TITLE
Edit CI trigger

### DIFF
--- a/.github/workflows/compose-ci.yml
+++ b/.github/workflows/compose-ci.yml
@@ -9,7 +9,6 @@ on:
 
 jobs:
   test-all:
-    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
 
     services:

--- a/.github/workflows/compose-ci.yml
+++ b/.github/workflows/compose-ci.yml
@@ -1,14 +1,15 @@
 name: docker compose tests
 
 on:
-  push:
-    branches: [ master, main, development]
-  # pull_request:
+  # push:
   #   branches: [ master, main, development]
+  pull_request:
+    branches: [ master, main, development]
   workflow_dispatch:
 
 jobs:
   test-all:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
 
     services:


### PR DESCRIPTION
- Job should run before a merge
- Job is therefore executed when a pull request is added
- Trigger on push is not needed