### PR TITLE
Add localhost to ALLOWED_HOSTS

### DIFF
--- a/evoks/evoks/settings.py
+++ b/evoks/evoks/settings.py
@@ -76,7 +76,7 @@ DEBUG = get_env('DJANGO_DEBUG', 'False') == 'True'
 # set to False to disable Browser-sync
 TAILWIND_DEV_MODE = False
 
-ALLOWED_HOSTS = [PUBLICURL]
+ALLOWED_HOSTS = ['localhost', PUBLICURL]
 
 
 LOGIN_REDIRECT_URL = '/vocabularies'


### PR DESCRIPTION
- docker compose health check using curl fails if localhost not in allowed_hosts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded the allowed hosts for the application to include both 'localhost' and the specified public URL, improving accessibility.
  
- **Refactor**
	- Minor adjustments made to the environment variable retrieval process for better handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->