### PR TITLE
Fix envsubst for skosmos-dev

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -13,9 +13,6 @@ services:
     container_name: evokstest_testrunner
     entrypoint: >
       sh -c "set -e &&
-             export BASEHREF && 
-             envsubst '$$BASEHREF' < /code/skosmos-dev/config-template.ttl > /code/skosmos-dev/config.ttl && 
-             envsubst '$$BASEHREF' < /code/skosmos-live/config-template.ttl > /code/skosmos-live/config.ttl && 
              cd ./evoks &&
              python manage.py migrate &&
              coverage run manage.py test -v 3 tests/model/ tests/migration/ tests/skosmos/ tests/fuseki/ tests/views/ tests/evoks &&

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -153,7 +153,7 @@ services:
       dockerfile: dockerfiles/Dockerfile.ubuntu
     hostname: skosmos-dev
     environment:
-      - BASEHREF="${PUBLICURL:-http://localhost}:${PROXY_PORT:-9000}/skosmos-dev/"
+      - BASEHREFDEV="${PUBLICURL:-http://localhost}:${PROXY_PORT:-9000}/skosmos-dev/"
     depends_on: 
       - fuseki-dev
     networks:
@@ -161,11 +161,12 @@ services:
       - frontnet
     volumes:
       - ./skosmos-dev/config-template.ttl:/var/www/html/config-template.ttl
+      - ./skosmos-dev/config.ttl:/var/www/html/config.ttl
       - static-skosmos-dev:/var/www/html/resource
     restart: unless-stopped
     command: >
-      /bin/bash -c "export BASEHREF &&
-      envsubst '$$BASEHREF' < /var/www/html/config-template.ttl > /var/www/html/config.ttl &&
+      /bin/bash -c "export BASEHREFDEV &&
+      envsubst '$$BASEHREFDEV' < /var/www/html/config-template.ttl > /var/www/html/config.ttl &&
       /usr/sbin/apache2ctl -D FOREGROUND"
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:80 || exit 1"]
@@ -181,7 +182,7 @@ services:
       dockerfile: dockerfiles/Dockerfile.ubuntu
     hostname: skosmos-live
     environment:
-      - BASEHREF="${PUBLICURL:-http://localhost}:${PROXY_PORT:-9000}/skosmos-live/"
+      - BASEHREFLIVE="${PUBLICURL:-http://localhost}:${PROXY_PORT:-9000}/skosmos-live/"
     depends_on: 
       - fuseki-live
     networks:
@@ -189,11 +190,12 @@ services:
       - frontnet
     volumes:
       - ./skosmos-live/config-template.ttl:/var/www/html/config-template.ttl
+      - ./skosmos-live/config.ttl:/var/www/html/config.ttl
       - static-skosmos-live:/var/www/html/resource
     restart: unless-stopped
     command: >
-      /bin/bash -c "export BASEHREF &&
-      envsubst '$$BASEHREF' < /var/www/html/config-template.ttl > /var/www/html/config.ttl &&
+      /bin/bash -c "export BASEHREFLIVE &&
+      envsubst '$$BASEHREFLIVE' < /var/www/html/config-template.ttl > /var/www/html/config.ttl &&
       /usr/sbin/apache2ctl -D FOREGROUND"
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:80 || exit 1"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,13 +62,8 @@ services:
     container_name: evoks_${INSTANCE_NAME:-defaultinstance}_web
     build:
       context: "."
-    environment:
-      - BASEHREF="${PUBLICURL:-http://localhost}:${PROXY_PORT:-9000}/skosmos-dev/"
     entrypoint: >
-      sh -c "export BASEHREF && 
-      envsubst '$$BASEHREF' < /code/skosmos-dev/config-template.ttl > /code/skosmos-dev/config.ttl && 
-      envsubst '$$BASEHREF' < /code/skosmos-live/config-template.ttl > /code/skosmos-live/config.ttl && 
-      python ./evoks/manage.py migrate && 
+      sh -c "python ./evoks/manage.py migrate && 
       python ./evoks/manage.py collectstatic --noinput --verbosity 0 && 
       gunicorn evoks.wsgi:application --bind 0.0.0.0:8000 --chdir evoks"
     depends_on:
@@ -156,23 +151,22 @@ services:
     build:
       context: https://github.com/NatLibFi/Skosmos.git#v2.17
       dockerfile: dockerfiles/Dockerfile.ubuntu
-    # to change port here, use .env file
     hostname: skosmos-dev
-    # environment:
-    #   - BASEHREF="${PUBLICURL:-http://localhost}:${PROXY_PORT:-9000}/skosmos-dev/"
+    environment:
+      - BASEHREF="${PUBLICURL:-http://localhost}:${PROXY_PORT:-9000}/skosmos-dev/"
     depends_on: 
       - fuseki-dev
     networks:
       - fuseki-dev
       - frontnet
     volumes:
-      # - ./skosmos-dev/config-template.ttl:/var/www/html/config-template.ttl
+      - ./skosmos-dev/config-template.ttl:/var/www/html/config-template.ttl
       - static-skosmos-dev:/var/www/html/resource
     restart: unless-stopped
-    # command: >
-    #   /bin/bash -c "export BASEHREF &&
-    #   envsubst '$$BASEHREF' < /var/www/html/config-template.ttl > /var/www/html/config.ttl && cat /var/www/html/config.ttl &&
-    #   /usr/sbin/apache2ctl -D FOREGROUND"
+    command: >
+      /bin/bash -c "export BASEHREF &&
+      envsubst '$$BASEHREF' < /var/www/html/config-template.ttl > /var/www/html/config.ttl &&
+      /usr/sbin/apache2ctl -D FOREGROUND"
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:80 || exit 1"]
       interval: 20s

--- a/skosmos-dev/config-template.ttl
+++ b/skosmos-dev/config-template.ttl
@@ -7,7 +7,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :config a skosmos:Configuration ;
-    skosmos:baseHref ${BASEHREF} ;
+    skosmos:baseHref ${BASEHREFDEV} ;
     skosmos:customCss "resource/css/stylesheet.css" ;
     skosmos:feedbackAddress "" ;
     skosmos:feedbackEnvelopeSender "" ;

--- a/skosmos-dev/config.ttl
+++ b/skosmos-dev/config.ttl
@@ -7,7 +7,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :config a skosmos:Configuration ;
-    skosmos:baseHref ${BASEHREF} ;
+    skosmos:baseHref ${BASEHREFDEV} ;
     skosmos:customCss "resource/css/stylesheet.css" ;
     skosmos:feedbackAddress "" ;
     skosmos:feedbackEnvelopeSender "" ;

--- a/skosmos-live/config-template.ttl
+++ b/skosmos-live/config-template.ttl
@@ -7,7 +7,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :config a skosmos:Configuration ;
-    skosmos:baseHref ${BASEHREF} ;
+    skosmos:baseHref ${BASEHREFLIVE} ;
     skosmos:customCss "resource/css/stylesheet.css" ;    
     skosmos:feedbackAddress "" ;
     skosmos:feedbackEnvelopeSender "" ;

--- a/skosmos-live/config.ttl
+++ b/skosmos-live/config.ttl
@@ -7,7 +7,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 :config a skosmos:Configuration ;
-    skosmos:baseHref ${BASEHREF} ;
+    skosmos:baseHref ${BASEHREFLIVE} ;
     skosmos:customCss "resource/css/stylesheet.css" ;    
     skosmos:feedbackAddress "" ;
     skosmos:feedbackEnvelopeSender "" ;


### PR DESCRIPTION
- Hotfix:
- uncomment envsubst command for BASEHREF of skomos-dev
- remove obsolete envsubst command for skosmos in web service

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Streamlined initialization process for services, ensuring proper execution order of commands.
  
- **Bug Fixes**
	- Updated environment variables for `skosmos-dev` and `skosmos-live` services to reflect new base URL references.

- **Chores**
	- Added healthcheck for the `change-vol-ownership` service to monitor permission change commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->