### PR TITLE
Fix error in building BASEHREF for skosmos

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -153,7 +153,7 @@ services:
       dockerfile: dockerfiles/Dockerfile.ubuntu
     hostname: skosmos-dev
     environment:
-      - BASEHREFDEV="http://${PUBLICURL:-http://localhost}:${PROXY_PORT:-9000}/skosmos-dev/"
+      - BASEHREFDEV="http://${PUBLICURL:-localhost}:${PROXY_PORT:-9000}/skosmos-dev/"
     depends_on: 
       - fuseki-dev
     networks:
@@ -182,7 +182,7 @@ services:
       dockerfile: dockerfiles/Dockerfile.ubuntu
     hostname: skosmos-live
     environment:
-      - BASEHREFLIVE="http://${PUBLICURL:-http://localhost}:${PROXY_PORT:-9000}/skosmos-live/"
+      - BASEHREFLIVE="http://${PUBLICURL:-localhost}:${PROXY_PORT:-9000}/skosmos-live/"
     depends_on: 
       - fuseki-live
     networks:


### PR DESCRIPTION
- Removed double http when building URL for skosmos

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration**
	- Updated default URL configuration for development and live services
	- Removed redundant `http://` prefix from default environment variables in Docker Compose file

<!-- end of auto-generated comment: release notes by coderabbit.ai -->