### PR TITLE
Supress warning about url pattern

### DIFF
--- a/evoks/evoks/settings.py
+++ b/evoks/evoks/settings.py
@@ -225,3 +225,7 @@ STATIC_ROOT = BASE_DIR / "theme/static"
 # https://docs.djangoproject.com/en/3.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+# Supress this warning until it is solved
+# (urls.W002) Your URL pattern '/<group_name>' [name='teams'] has a route beginning with a '/'. Remove this slash as it is unnecessary. If this pattern is targeted in an include(), ensure the include() pattern has a trailing '/'.
+SILENCED_SYSTEM_CHECKS = ['urls.W002']


### PR DESCRIPTION
- Warning is about URL pattern with beginning forward slash
- only unneccesary, but not critical
- will be suppressed for increased usability until solved
- See issue url pattern warning #255

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Suppressed a specific Django system check warning related to URL patterns to streamline configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->