### PR TITLE
Remove unneccesary keep alive of service

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -9,6 +9,12 @@ services:
     container_name: evokstest_postgres
     restart: "no"
 
+  change-vol-ownership:
+    container_name: evokstest_change-vol-ownership
+    command: >
+      sh -c "(chmod -R 777 /tmp/change-ownership-fuseki-dev && chmod -R 777 /tmp/change-ownership-fuseki-live ; echo $? > /tmp/chmod_exit_status) ; tail -f /dev/null"
+    restart: "no"
+
   web:
     container_name: evokstest_testrunner
     entrypoint: >

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -11,6 +11,7 @@ services:
 
   change-vol-ownership:
     container_name: evokstest_change-vol-ownership
+    # Keep container running during tests to ensure proper --exit-code-from functionality
     command: >
       sh -c "(chmod -R 777 /tmp/change-ownership-fuseki-dev && chmod -R 777 /tmp/change-ownership-fuseki-live ; echo $? > /tmp/chmod_exit_status) ; tail -f /dev/null"
     restart: "no"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,6 @@ services:
     # execute chmod to enable writing to the volume by other containers
     # write exit status to file
     # only exit status of last command is used, but thats ok since either both or none should fail
-    # keep container running to enable abort-on-container-exit for testrunner container
     command: >
       sh -c "(chmod -R 777 /tmp/change-ownership-fuseki-dev && chmod -R 777 /tmp/change-ownership-fuseki-live ; echo $? > /tmp/chmod_exit_status)"
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ services:
     # only exit status of last command is used, but thats ok since either both or none should fail
     # keep container running to enable abort-on-container-exit for testrunner container
     command: >
-      sh -c "(chmod -R 777 /tmp/change-ownership-fuseki-dev && chmod -R 777 /tmp/change-ownership-fuseki-live ; echo $? > /tmp/chmod_exit_status) ; tail -f /dev/null"
+      sh -c "(chmod -R 777 /tmp/change-ownership-fuseki-dev && chmod -R 777 /tmp/change-ownership-fuseki-live ; echo $? > /tmp/chmod_exit_status)"
     healthcheck:
       test: ["CMD-SHELL", "cat /tmp/chmod_exit_status | grep -q '^0$'"]
       interval: 5s


### PR DESCRIPTION
- change-ownership does not have to stay alive
- has to stay alive for tests because otherwise "--exit-code-from" option will fail

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Added a new service for managing volume ownership in the Docker Compose configuration.
	- Modified the service command to change directory permissions and exit after completion, enhancing control flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->