### PR TITLE
Upgrade debian

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.2-slim-buster
+FROM python:3.9.2-slim-bookworm
 
 WORKDIR /code
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.2-slim-bookworm
+FROM python:3.9-slim-bookworm
 
 WORKDIR /code
 


### PR DESCRIPTION
Fix old debian version of python docker image

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the base Docker image to use a newer version of Debian for Python 3.9 deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->